### PR TITLE
disable import/no-nodejs-modules rule in node environment

### DIFF
--- a/packages/node/index.yaml
+++ b/packages/node/index.yaml
@@ -7,3 +7,4 @@ rules:
   no-path-concat: 2
   no-process-exit: 2
   no-sync: 1
+  import/no-nodejs-modules: 0


### PR DESCRIPTION
Obviously you can import nodejs modules when you're running in a node environment :P