### PR TITLE
bump/fix peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ See individual packages
 - [Node.js](https://github.com/kunalgolani/eslint-config/tree/master/packages/node)
 - [React Native](https://github.com/kunalgolani/eslint-config/tree/master/packages/react-native)
 
+**Note**: you should include postcss@7 into devDependencies of your project manually. eslint-config-* packages requires it as a peer and does not install it to avoid swallowing the typical node_modules directory.
+
 To add a git-hook to your commits, consider using [husky](https://github.com/typicode/husky)
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See individual packages
 - [Node.js](https://github.com/kunalgolani/eslint-config/tree/master/packages/node)
 - [React Native](https://github.com/kunalgolani/eslint-config/tree/master/packages/react-native)
 
-**Note**: you should include postcss@7 into devDependencies of your project manually. eslint-config-* packages requires it as a peer and does not install it to avoid swallowing the typical node_modules directory.
+Eslint-config-* packages are compatible with 5 and 6th versions of eslint.
 
 To add a git-hook to your commits, consider using [husky](https://github.com/typicode/husky)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ See individual packages
 - [Node.js](https://github.com/kunalgolani/eslint-config/tree/master/packages/node)
 - [React Native](https://github.com/kunalgolani/eslint-config/tree/master/packages/react-native)
 
+**Note**: eslint-config-recommended comes with esnext, node and react-native. If you don't need all these configs, you can install them individually (it's preferred, because you can keep node_modules light weight).
+
 Eslint-config-* packages are compatible with 5 and 6th versions of eslint.
 
 To add a git-hook to your commits, consider using [husky](https://github.com/typicode/husky)

--- a/packages/esnext/package.json
+++ b/packages/esnext/package.json
@@ -31,15 +31,16 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/esnext#readme",
   "dependencies": {
-    "babel-eslint": "^10.0.1",
-    "eslint": "^5.6.0",
     "eslint-plugin-babel": "^5.2.1",
     "eslint-plugin-import": "^2.14.0"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.6.0",
     "js-yaml": "^3.12.0"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "babel-eslint": "10",
+    "eslint": "5 || 6"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,13 +28,13 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/node#readme",
   "dependencies": {
-    "eslint": "^5.6.0",
     "eslint-config-esnext": "^4.0.0"
   },
   "devDependencies": {
+    "eslint": "^5.6.0",
     "js-yaml": "^3.12.0"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "5 || 6"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -29,15 +29,15 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/react-native#readme",
   "dependencies": {
-    "eslint": "^5.6.0",
     "eslint-config-esnext": "^4.0.0",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-react-native": "^3.3.0"
   },
   "devDependencies": {
+    "eslint": "^5.6.0",
     "js-yaml": "^3.12.0"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "5 || 6"
   }
 }

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -35,14 +35,16 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/recommended#readme",
   "dependencies": {
-    "eslint-config-esnext": "^4.0.0",
-    "eslint-config-node": "^4.0.0",
-    "eslint-config-react-native": "^4.0.0"
+    "eslint-config-esnext": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^5.6.0"
   },
   "peerDependencies": {
     "eslint": "5 || 6"
+  },
+  "optionalDependency": {
+    "eslint-config-react-native": "^4.0.0",
+    "eslint-config-node": "^4.0.0"
   }
 }

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -35,12 +35,14 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/recommended#readme",
   "dependencies": {
-    "eslint": "^5.6.0",
     "eslint-config-esnext": "^4.0.0",
     "eslint-config-node": "^4.0.0",
     "eslint-config-react-native": "^4.0.0"
   },
+  "devDependencies": {
+    "eslint": "^5.6.0"
+  }
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "5 || 6"
   }
 }

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -35,16 +35,14 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/recommended#readme",
   "dependencies": {
-    "eslint-config-esnext": "^4.0.0"
+    "eslint-config-esnext": "^4.0.0",
+    "eslint-config-react-native": "^4.0.0",
+    "eslint-config-node": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^5.6.0"
   },
   "peerDependencies": {
     "eslint": "5 || 6"
-  },
-  "optionalDependency": {
-    "eslint-config-react-native": "^4.0.0",
-    "eslint-config-node": "^4.0.0"
   }
 }

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "eslint": "^5.6.0"
-  }
+  },
   "peerDependencies": {
     "eslint": "5 || 6"
   }


### PR DESCRIPTION
fixes #11 

it's not sense to include any package into both dependencies and peerDependencies. 

eslint and other big common tools must be in peer deps and dev deps, actually

----

For example, my project has many many of installed postcss packages :-( 
`find node_modules -name postcss | grep -v postcss-`
<img width="655" alt="Screenshot 2019-08-16 at 11 04 57" src="https://user-images.githubusercontent.com/6201068/63154020-5f2c5600-c018-11e9-81c6-758249083d7f.png">


```
find node_modules -name postcss | grep -v postcss- | sed 's|$|/package.json|' | while read f; do cat $f | jq -r .version; done | tr "\n" ',' | sed 's/,/, /g'
```
→ 7.0.17, 7.0.16, 7.0.14, 7.0.16, 7.0.16, 7.0.17, 7.0.16, 7.0.16, 7.0.16, 7.0.14, 7.0.16, 7.0.16,

---

# todo
- [x] bump/fix peer deps
- [x] write about expected peer deps into readme
- [ ] bump eslint-config-esnext, -node, -rn versions in the eslint-config-recommended
