### PR TITLE
feat: include eslint 7 in peer deps

### DIFF
--- a/packages/esnext/package.json
+++ b/packages/esnext/package.json
@@ -40,6 +40,6 @@
     "js-yaml": "^3.12.0"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": ">=6 <=7"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,13 +28,13 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/node#readme",
   "dependencies": {
-    "eslint": "^6.8.0",
+    "eslint": "^7.22.0",
     "eslint-config-esnext": "^4.1.0"
   },
   "devDependencies": {
     "js-yaml": "^3.13.1"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": ">=6 <=7"
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/kunalgolani/eslint-config/tree/master/packages/react-native#readme",
   "dependencies": {
-    "eslint": "^6.8.0",
+    "eslint": "^7.22.0",
     "eslint-config-esnext": "^4.1.0",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-native": "^3.8.1"
@@ -38,6 +38,6 @@
     "js-yaml": "^3.13.1"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": ">=6 <=7"
   }
 }

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -41,6 +41,6 @@
     "eslint-config-react-native": "^4.1.0"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": ">=6 <=7"
   }
 }


### PR DESCRIPTION
npm 7's new peer  dependency handling needs this.

closes #48 